### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,8 +4,5 @@ engines:
     
 ratings:
    paths:
-<<<<<<< HEAD
    - "**.js"
-=======
-   - "**.js"
->>>>>>> parent of f2042bb... Initial commit
+


### PR DESCRIPTION
Remove syntax errors causing Code Climate to error builds.
