### PR TITLE
Fast resizing

### DIFF
--- a/src/Exsurge.Chant.js
+++ b/src/Exsurge.Chant.js
@@ -828,10 +828,17 @@ export class ChantScore {
     if (this.annotation)
       this.annotation.recalculateMetrics(ctxt);
 
-    // boot the compilation process
-    setTimeout(() => {
-      this.compileElement(ctxt, 0, finishedCallback);
-    }, 0);
+    if (this.compiled) {
+      setTimeout(() => {
+        if (finishedCallback)
+          finishedCallback();
+      }, 0);
+    } else {
+      // boot the compilation process
+      setTimeout(() => {
+        this.compileElement(ctxt, 0, finishedCallback);
+      }, 0);
+    }
   }
 
   compileElement(ctxt, index, finishedCallback) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,13 +54,24 @@ ChantVisualElementPrototype.createdCallback = function() {
 
   var _element = this;
 
-  // perform layout on the chant
-  score.performLayout(ctxt, function() {
-    score.layoutChantLines(ctxt, 0, function() {
-      // render the score to svg code
-      _element.innerHTML = score.createDrawable(ctxt);
+  var width = 0;
+  var doLayout = function() {
+    var newWidth = _element.parentElement.clientWidth;
+    if(width === newWidth) return;
+    width = newWidth;
+    // perform layout on the chant
+    score.performLayout(ctxt, function() {
+      score.layoutChantLines(ctxt, width, function() {
+        // render the score to svg code
+        _element.innerHTML = score.createDrawable(ctxt);
+      });
     });
-  });
+  }
+  doLayout();
+  if (window.addEventListener)
+    window.addEventListener('resize',doLayout,false);
+  else if (window.attachEvent)
+    window.attachEvent('onresize',doLayout);
 }
 
 ChantVisualElementPrototype.attachedCallback = function() {

--- a/test/index.html
+++ b/test/index.html
@@ -14,19 +14,19 @@
   <![endif]-->
 </head>
 
-<body onload="updateChant()" onresize="updateChant()">
+<body onload="updateChant()" onresize="layoutChant()">
 
   <h1>exsurge Test Page</h1>
 
   <p><em>This is the simplest of test pages, just to start testing out exsurge. For more information, please visit <a href="https://github.com/frmatthew/exsurge/">the exsurge GitHub pages</a>.</em></p>
 
-  <chant-visual use-drop-cap="false" annotation="IV">(c4) Pu(g)er(h) na(i)tus(h) est(ghg) ()</chant-visual>
+  <chant-visual use-drop-cap="false" annotation="IV">(c3) PU(ei)ER(i) *() na(iji)tus(h) est(hhh) no(ih/ji)bis,(i) (;) et(ei~) fí(iji)li(hg)us(f) da(hhi)tus(h) est(h) no(hihh)bis:(efe) (:) cu(e)jus(f) im(h)pé(gi!jk)ri(ih)um(h) (,) su(h)per(h) hú(ih/ji)me(hg)rum(hhh) e(hf//hghvGF)jus:(gf) (:) et(hg) vo(h)cá(hji)bi(h)tur(hhh) no(h)men(hhh) e(highvGF)jus,(gf) (;) ma(hj)gni(i) con(eh~)sí(h)li(hhhf)i(f) An(fhf!gwh)ge(efe)lus.(e) Ps.(::) Can(ehg)tá(hi)te(i) Dó(i)mi(i)no(i) cán(ik)ti(j)cum(j) no(ji)vum:(ij) *(:) qui(ig)a(hi) mi(i)ra(i)bí(i!jwk)li(i)a(h) fe(hhh)cit.(fe) (::) Gló(ehg)ri(hi)a(i) Pa(i)tri.(i) (::) E(i) u(i!jwk) o(i) u(h) a(hhh) e.(fe) (::)</chant-visual>
 
   <label>Enter your GABC code here:</label><br/>
-  <textarea rows="10" cols="80" id="gabcSource" oninput="updateChant()" onchange="updateChant()">(c3) PU(ei)ER(hg)</textarea>
+  <textarea rows="10" cols="80" id="gabcSource" oninput="updateChant()" onchange="updateChant()">(c3) PU(ei)ER(i) *() na(iji)tus(h) est(hhh) no(ih/ji)bis,(i) (;) et(ei~) fí(iji)li(hg)us(f) da(hhi)tus(h) est(h) no(hihh)bis:(efe) (:) cu(e)jus(f) im(h)pé(gi!jk)ri(ih)um(h) (,) su(h)per(h) hú(ih/ji)me(hg)rum(hhh) e(hf//hghvGF)jus:(gf) (:) et(hg) vo(h)cá(hji)bi(h)tur(hhh) no(h)men(hhh) e(highvGF)jus,(gf) (;) ma(hj)gni(i) con(eh~)sí(h)li(hhhf)i(f) An(fhf!gwh)ge(efe)lus.(e) Ps.(::) Can(ehg)tá(hi)te(i) Dó(i)mi(i)no(i) cán(ik)ti(j)cum(j) no(ji)vum:(ij) *(:) qui(ig)a(hi) mi(i)ra(i)bí(i!jwk)li(i)a(h) fe(hhh)cit.(fe) (::) Gló(ehg)ri(hi)a(i) Pa(i)tri.(i) (::) E(i) u(i!jwk) o(i) u(h) a(hhh) e.(fe) (::)</textarea>
   <div id="chant-container">
   </div>
-
+  <script src="//cdnjs.cloudflare.com/ajax/libs/document-register-element/0.5.3/document-register-element.js">/* W3C Custom Elements */</script>
   <script type="text/javascript" src="../dist/exsurge.js"></script>
   <script type="text/javascript">
     /* testing exsurge */
@@ -37,20 +37,21 @@
     ctxt.dropCapTextFont = ctxt.lyricTextFont;
     ctxt.annotationTextFont = ctxt.lyricTextFont;
 
-
+    var score;
+    var gabcSource = document.getElementById('gabcSource');
+    var chantContainer = document.getElementById('chant-container');
     var updateChant = function() {
-      
-      var gabcSource = document.getElementById('gabcSource');
-      var chantContainer = document.getElementById('chant-container');
-      
-      var score = exsurge.Gabc.loadChantScore(ctxt, gabcSource.value, true);
+      score = exsurge.Gabc.loadChantScore(ctxt, gabcSource.value, true);
     
       // add an annotation
       //score.annotation = new exsurge.Annotation(ctxt, "Ant. X");
 
+      layoutChant();
+    }
+    var layoutChant = function() {
       // perform layout on the chant
       score.performLayout(ctxt, function() {
-        score.layoutChantLines(ctxt, chantContainer.offsetWidth * .9, function() {
+        score.layoutChantLines(ctxt, chantContainer.clientWidth, function() {
           // render the score to svg code
           chantContainer.innerHTML = score.createDrawable(ctxt);
         });


### PR DESCRIPTION
I changed test/index.html so that it doesn't re-run the entire compilation process if the score has already been compiled.

I also changed index.js to set the width of <chant-visual> elements based on their parent's width, and then update this when the window is resized.

I also added a document.registerElement polyfill to test/index.html
