### PR TITLE
Small Caps fix

### DIFF
--- a/src/Exsurge.Drawing.js
+++ b/src/Exsurge.Drawing.js
@@ -546,7 +546,7 @@ MarkupStackFrame.createStackFrame = function(symbol, startIndex) {
       properties = 'fill:#f00;'; // SVG text color is set by the fill property
       break;
     case smallCapsMarkup:
-      properties = "font-feature-settings:'smcp';-webkit-font-feature-settings:'smcp';";
+      properties = "font-variant:small-caps;font-feature-settings:'smcp';-webkit-font-feature-settings:'smcp';";
       break;
   }
 


### PR DESCRIPTION
Since is reccomended not to use `font-feature-*` ([https://developer.mozilla.org/pl/docs/Web/CSS/font-feature-settings](url)), `font-variant` has been added.,
