### PR TITLE
fix compile loop

### DIFF
--- a/src/Exsurge.Chant.js
+++ b/src/Exsurge.Chant.js
@@ -885,7 +885,7 @@ export class ChantScore {
     do {
       var notation = this.notations[index++];
       notation.performLayout(ctxt);
-    } while (index < this.notations.length && timeout < new Date().getTime());
+    } while (index < this.notations.length && new Date().getTime() < timeout);
 
     // schedule the next block of processing
     setTimeout(() => {


### PR DESCRIPTION
It should loop through, calling performLayout while the current time is LESS than the timeout, not while the timeout is less than the current time.  It is much faster at compiling when it doesn't set a new timer for each call to notation.performLayout()
