### PR TITLE
Fixed a clef related bug

### DIFF
--- a/src/Exsurge.Chant.js
+++ b/src/Exsurge.Chant.js
@@ -916,8 +916,7 @@ export class ChantScore {
     var y = 0;
     var currIndex = 0;
 
-    if (ctxt.activeClef === null)
-      ctxt.activeClef = this.startingClef;
+    ctxt.activeClef = this.startingClef;
 
     do {
 


### PR DESCRIPTION
When laying out chant lines, there is no harm done by always setting the active clef to the score's starting clef when starting out, because it starts from the beginning of the score, and in fact this was causing it to always start with the _last_ clef given in the chant, rather than the first.
