### PR TITLE
Better identify last syllable

### DIFF
--- a/src/Exsurge.Gabc.js
+++ b/src/Exsurge.Gabc.js
@@ -244,11 +244,11 @@ export class Gabc {
       if (!cne.isNeume && cne.constructor.name !== TextOnly.name)
         proposedLyricType = LyricType.Directive;
       // otherwise trye to guess the lyricType for the first lyric anyway
-      else if (currSyllable === 0 && matches.length === 1)
+      else if (currSyllable === 0 && j === (matches.length - 1))
         proposedLyricType = LyricType.SingleSyllable;
-      else if (currSyllable === 0 && matches.length > 1)
+      else if (currSyllable === 0 && j < (matches.length - 1))
         proposedLyricType = LyricType.BeginningSyllable;
-      else if (currSyllable === matches.length - 1)
+      else if (j === matches.length - 1)
         proposedLyricType = LyricType.EndingSyllable;
       else
         proposedLyricType = LyricType.MiddleSyllable;


### PR DESCRIPTION
When no space is given immediately after a clef, e.g., "(c4)IN(ed~) nó(g)mi(hj)ne(j)" it was not finding the last syllable of the first word, because the number of syllables was not equal to the length of the matches array, since the first match (the clef) had no lyrics.

I'm not sure that this is completely standard GABC, since all the examples do give a space after the clef, but it doesn't cause a problem for Gregorio to do it this way, and there are at least 30 scores in GregoBase that begin like this with no space between the clef and first syllable.
