### PR TITLE
Fix problem with relaying out scores with annotations:

### DIFF
--- a/src/Exsurge.Chant.js
+++ b/src/Exsurge.Chant.js
@@ -449,8 +449,8 @@ export class ChantLine extends ChantLayoutElement {
 
       if (this.score.annotation !== null) {
         // annotations use dominant-baseline to align text to the top
-        this.score.annotation.bounds.x += this.staffLeft / 2;
-        this.score.annotation.bounds.y +=  - ctxt.staffInterval * 3;
+        this.score.annotation.bounds.x = this.staffLeft / 2;
+        this.score.annotation.bounds.y =  - ctxt.staffInterval * 3;
       }
     }
 


### PR DESCRIPTION
When calling score.layoutChantLines() multiple times on a score with an annotation, the annotation was only being positioned correctly the first time, because the x and y values were endlessly accumulating.  The upshot was that after re-laying out a score, e.g., because the window was resized, the annotations would no longer be visible.
