### PR TITLE
Fix for determining where to put line breaks

### DIFF
--- a/src/Exsurge.Chant.js
+++ b/src/Exsurge.Chant.js
@@ -569,7 +569,7 @@ export class ChantLine extends ChantLayoutElement {
     var curr = this.startingClef, prev = null, prevWithLyrics = null;
 
     // estimate how much space we have available to us
-    var rightBoundary = this.staffRight - Glyphs.CustosLong.bounds.width - ctxt.intraNeumeSpacing * 4; // possible custos on the line
+    var rightBoundary = this.staffRight - Glyphs.CustosLong.bounds.width * ctxt.glyphScaling - ctxt.intraNeumeSpacing * 4; // possible custos on the line
 
     // iterate through the notations, fittng what we can on this line
     var i, j;


### PR DESCRIPTION
I think it should be multiplying the CustosLong gylph width by ctxt.glyphScaling to give rightBoundary a more meaningful value.  It should also really allow all the way up to staffRight on the final system, but I haven't thought much about how to implement that.
