### PR TITLE
Improve line breaks and justification of final line when lyrics might extend beyond staffRight

### DIFF
--- a/src/Exsurge.Drawing.js
+++ b/src/Exsurge.Drawing.js
@@ -1058,6 +1058,18 @@ export class ChantNotationElement extends ChantLayoutElement {
     return this.bounds.x + this.lyrics[index].bounds.x + this.lyrics[index].bounds.width;
   }
 
+  getLyricLeftMost() {
+    return this.bounds.x + Math.min.apply(null, this.lyrics.map(function(lyrics){
+      return lyrics.bounds.x;
+    }));
+  }
+
+  getLyricRightMost() {
+    return this.bounds.x + Math.max.apply(null, this.lyrics.map(function(lyrics){
+      return lyrics.bounds.x + lyrics.bounds.width;
+    }));
+  }
+
   // used by subclasses while building up the chant notations.
   addVisualizer(chantLayoutElement) {
     if (this.bounds.isEmpty())


### PR DESCRIPTION
Don't consider a notation to fit on the current line if it has lyrics that extend beyond staffRight

Handle justification of a final line in which the last lyric would have extended to the right of the final bar.
