### PR TITLE
Allow mangling

### DIFF
--- a/src/Exsurge.Chant.ChantLine.js
+++ b/src/Exsurge.Chant.ChantLine.js
@@ -441,7 +441,7 @@ export class ChantLine extends ChantLayoutElement {
         ctxt.activeClef = curr;
 
       // line breaks are a special case indicating to stop processing here
-      if (curr.constructor.name === ChantLineBreak.name && width > 0) {
+      if (curr.constructor === ChantLineBreak && width > 0) {
         this.justify = curr.justify;
         break;
       }
@@ -533,7 +533,7 @@ export class ChantLine extends ChantLayoutElement {
       if (prevWithLyrics !== null && prevWithLyrics.lyrics[0].allowsConnector() && !prevWithLyrics.lyrics[0].needsConnector)
         continue;
 
-      if (curr.constructor.name === ChantLineBreak.name)
+      if (curr.constructor === ChantLineBreak)
         continue;
 
       // otherwise, we can add space before this element
@@ -622,7 +622,7 @@ export class ChantLine extends ChantLayoutElement {
       minY = Math.min(minY, notations[i].bounds.y);
       maxY = Math.max(maxY, notations[i].bounds.bottom());
 
-      if (notations[i].constructor.name === Custos.name) {
+      if (notations[i].constructor === Custos) {
         processElementForLedgerLine(notations[i]);
         continue;
       }

--- a/src/Exsurge.Drawing.js
+++ b/src/Exsurge.Drawing.js
@@ -1416,6 +1416,7 @@ export class ChantNotationElement extends ChantLayoutElement {
       inner += this.lyrics[i].createSvgFragment(ctxt);
 
     return QuickSvg.createFragment('g', {
+      // this.constructor.name will not be the same after being mangled by UglifyJS
       'class': 'ChantNotationElement ' + this.constructor.name,
       'transform': 'translate(' + this.bounds.x + ',' + 0 + ')'
     }, inner);

--- a/src/Exsurge.Gabc.js
+++ b/src/Exsurge.Gabc.js
@@ -248,7 +248,7 @@ export class Gabc {
       for (var i = 0; i < items.length; i++) {
         var cne = items[i];
 
-        if (cne.isAccidental || cne.constructor.name === Signs.Custos.name)
+        if (cne.isAccidental || cne.constructor === Signs.Custos)
           continue;
 
         notationWithLyrics = cne
@@ -261,7 +261,7 @@ export class Gabc {
       var proposedLyricType;
       
       // if it's not a neume or a TextOnly notation, then make the lyrics a directive
-      if (!cne.isNeume && cne.constructor.name !== TextOnly.name)
+      if (!cne.isNeume && cne.constructor !== TextOnly)
         proposedLyricType = LyricType.Directive;
       // otherwise trye to guess the lyricType for the first lyric anyway
       else if (currSyllable === 0 && j === (matches.length - 1))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ var plugins = [];
 var outputFile;
 
 if (env === 'build') {
-  plugins.push(new UglifyJsPlugin({ minimize: true, mangle: false }));
+  plugins.push(new UglifyJsPlugin({ minimize: true }));
   outputFile = package.name + '.min.js';
 } else {
   outputFile = package.name + '.js';


### PR DESCRIPTION
Mangling will work again, by not depending on the use of the "name" property of functions.
In Exsurge.Drawing.js:1420 the class will still not be correct if the javascript has been mangled.
